### PR TITLE
Bugfixes and maintenance

### DIFF
--- a/quotedprintable.cpp
+++ b/quotedprintable.cpp
@@ -16,51 +16,55 @@
 
 #include "quotedprintable.h"
 
-QString& QuotedPrintable::encode(const QByteArray &input)
+QByteArray QuotedPrintable::encode(const QString &input)
 {
-    QString *output = new QString();
+    QByteArray output;
 
     char byte;
     const char hex[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
-    for (int i = 0; i < input.length() ; ++i)
+    QByteArray latin1 = input.toUtf8();
+    for (int i = 0; i < latin1.length() ; ++i)
     {
-        byte = input[i];
+        byte = latin1[i];
 
-        if ((byte == 0x20) || (byte >= 33) && (byte <= 126) && (byte != 61))
+        if ((byte == 0x20) || ((byte >= 33) && (byte <= 126)))
         {
-            output->append(byte);
+            output.append(byte);
         }
         else
         {
-            output->append('=');
-            output->append(hex[((byte >> 4) & 0x0F)]);
-            output->append(hex[(byte & 0x0F)]);
+            output.append('=');
+            output.append(hex[((byte >> 4) & 0x0F)]);
+            output.append(hex[(byte & 0x0F)]);
         }
     }
 
-    return *output;
+    return output;
 }
 
 
-QByteArray& QuotedPrintable::decode(const QString &input)
+QString QuotedPrintable::decode(const QByteArray &input)
 {
-    //                    0  1  2  3  4  5  6  7  8  9  :  ;  <  =  >  ?  @  A   B   C   D   E   F
-    const int hexVal[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13, 14, 15};
-
-    QByteArray *output = new QByteArray();
+    QByteArray output;
 
     for (int i = 0; i < input.length(); ++i)
     {
-        if (input.at(i).toAscii() == '=')
+        if (input.at(i) == '=' && i+2<input.length())
         {
-            output->append((hexVal[input.at(++i).toAscii() - '0'] << 4) + hexVal[input.at(++i).toAscii() - '0']);
+            QString strValue = input.mid((++i)++, 2);
+            bool converted;
+            char character = strValue.toUInt(&converted, 16);
+            if( converted )
+                output.append(character);
+            else
+                output.append( "=" + strValue);
         }
         else
         {
-            output->append(input.at(i).toAscii());
+            output.append(input.at(i));
         }
     }
 
-    return *output;
+    return QString::fromUtf8(output);
 }

--- a/quotedprintable.cpp
+++ b/quotedprintable.cpp
@@ -28,7 +28,7 @@ QByteArray QuotedPrintable::encode(const QString &input)
     {
         byte = latin1[i];
 
-        if ((byte == 0x20) || ((byte >= 33) && (byte <= 126)))
+        if ((byte == ' ') || ((byte >= 33) && (byte <= 126)  && (byte != '=')))
         {
             output.append(byte);
         }

--- a/quotedprintable.h
+++ b/quotedprintable.h
@@ -25,8 +25,8 @@ class QuotedPrintable : public QObject
     Q_OBJECT
 public:
 
-    static QString& encode(const QByteArray &input);
-    static QByteArray& decode(const QString &input);
+    static QByteArray encode(const QString &input);
+    static QString decode(const QByteArray &input);
 
 private:
     QuotedPrintable();


### PR DESCRIPTION
* Replaced deprecated „toAscii“ with „toLatin1“
* Fixed memory leaks
* Fixed compiler warning regarding || and &&
* Half encoded tags at the end no longer produce out of bound reads
* Malicous crafted encoded tags produce no more out of bound reads
* Fixed input / output types so that they IMHO make more sense
* Added „=“ to encoded characters